### PR TITLE
Implement mock database for categories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2251,6 +2251,11 @@
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
       "dev": true
     },
+    "angular-in-memory-web-api": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/angular-in-memory-web-api/-/angular-in-memory-web-api-0.9.0.tgz",
+      "integrity": "sha512-//PiJ5qb1+Yf/N7270ioQqR2laf4/Irjavg+M+WEn8y4At9LUoYgbQ5HVwvM5xUTlVlL0XkbJRLxREcGGNdIEw=="
+    },
     "ansi-colors": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
@@ -3484,8 +3489,7 @@
     "commander": {
       "version": "2.20.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
-      "dev": true
+      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
     },
     "commondir": {
       "version": "1.0.1",
@@ -5303,10 +5307,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.2.0.tgz",
-      "integrity": "sha512-Kb4xn5Qh1cxAKvQnzNWZ512DhABzyFNmsaJf3OAkWNa4NkaqWcNI8Tao8Tasi0/F4JD9oyG0YxuFyvyR57d+Gw==",
-      "dev": true,
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.3.1.tgz",
+      "integrity": "sha512-c0HoNHzDiHpBt4Kqe99N8tdLPKAnGCQ73gYMPWtAYM4PwGnf7xl8PBUHJqh9ijlzt2uQKaSRxbXRt+rZ7M2/kA==",
       "requires": {
         "neo-async": "^2.6.0",
         "optimist": "^0.6.1",
@@ -5317,8 +5320,7 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
       }
     },
@@ -7875,8 +7877,7 @@
     "neo-async": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
-      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
-      "dev": true
+      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw=="
     },
     "nice-try": {
       "version": "1.0.5",
@@ -8265,7 +8266,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "dev": true,
       "requires": {
         "minimist": "~0.0.1",
         "wordwrap": "~0.0.2"
@@ -8274,8 +8274,7 @@
         "minimist": {
           "version": "0.0.10",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
-          "dev": true
+          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
         }
       }
     },
@@ -10980,7 +10979,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
       "integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
-      "dev": true,
       "optional": true,
       "requires": {
         "commander": "~2.20.0",
@@ -10991,7 +10989,6 @@
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true,
           "optional": true
         }
       }
@@ -12932,8 +12929,7 @@
     "wordwrap": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
-      "dev": true
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
     },
     "worker-farm": {
       "version": "1.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3489,7 +3489,8 @@
     "commander": {
       "version": "2.20.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
+      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+      "dev": true
     },
     "commondir": {
       "version": "1.0.1",
@@ -5310,6 +5311,7 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.3.1.tgz",
       "integrity": "sha512-c0HoNHzDiHpBt4Kqe99N8tdLPKAnGCQ73gYMPWtAYM4PwGnf7xl8PBUHJqh9ijlzt2uQKaSRxbXRt+rZ7M2/kA==",
+      "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
         "optimist": "^0.6.1",
@@ -5320,7 +5322,8 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
         }
       }
     },
@@ -7877,7 +7880,8 @@
     "neo-async": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
-      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw=="
+      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
+      "dev": true
     },
     "nice-try": {
       "version": "1.0.5",
@@ -8266,6 +8270,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true,
       "requires": {
         "minimist": "~0.0.1",
         "wordwrap": "~0.0.2"
@@ -8274,7 +8279,8 @@
         "minimist": {
           "version": "0.0.10",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
+          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+          "dev": true
         }
       }
     },
@@ -10979,6 +10985,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
       "integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
+      "dev": true,
       "optional": true,
       "requires": {
         "commander": "~2.20.0",
@@ -10989,6 +10996,7 @@
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true,
           "optional": true
         }
       }
@@ -12929,7 +12937,8 @@
     "wordwrap": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+      "dev": true
     },
     "worker-farm": {
       "version": "1.7.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@angular/platform-browser": "~8.2.4",
     "@angular/platform-browser-dynamic": "~8.2.4",
     "@angular/router": "~8.2.4",
+    "angular-in-memory-web-api": "^0.9.0",
     "rxjs": "~6.4.0",
     "tslib": "^1.10.0",
     "zone.js": "~0.9.1"

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -1,7 +1,22 @@
 import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
+import { BoardComponent } from './board/board.component';
 
-const routes: Routes = [];
+const routes: Routes = [
+  {
+    path: '',
+    redirectTo: '/board',
+    pathMatch: 'full'
+  },
+  {
+    path: 'board',
+    component: BoardComponent
+  },
+  {
+    path: '**',
+    redirectTo: '/board',
+  },
+];
 
 @NgModule({
   imports: [RouterModule.forRoot(routes)],

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -34,6 +34,7 @@ import { HeaderComponent } from './header/header.component';
     HeaderComponent
   ],
   imports: [
+    AppRoutingModule,
     BrowserAnimationsModule,
     BrowserModule,
     HttpClientModule,
@@ -44,7 +45,6 @@ import { HeaderComponent } from './header/header.component';
     MatToolbarModule,
     MatButtonModule,
     MatInputModule,
-    AppRoutingModule,
     // The HttpClientInMemoryWebApiModule module intercepts HTTP requests
     // and returns simulated server responses.
     // Remove it when a real server is ready to receive requests.

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,4 +1,5 @@
 import { NgModule } from '@angular/core';
+
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatDividerModule } from '@angular/material/divider';
@@ -6,33 +7,22 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { MatListModule } from '@angular/material/list';
 import { MatToolbarModule } from '@angular/material/toolbar';
+
+import { HttpClientInMemoryWebApiModule } from 'angular-in-memory-web-api';
+import { InMemoryDataService } from './in-memory-data.service';
+import { HttpClientModule } from '@angular/common/http';
+
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 import { AppRoutingModule } from './app-routing.module';
+
 import { AppComponent } from './app.component';
 import { BoardComponent } from './board/board.component';
 import { CategoryDetailComponent } from './category-detail/category-detail.component';
 import { FooterComponent } from './footer/footer.component';
-import { RouterModule, Routes } from '@angular/router';
 import { TaskDetailComponent } from './task-detail/task-detail.component';
 import { HeaderComponent } from './header/header.component';
-
-const appRoutes: Routes = [
-  {
-    path: '',
-    redirectTo: '/board',
-    pathMatch: 'full'
-  },
-  {
-    path: 'board',
-    component: BoardComponent
-  },
-  {
-    path: '**',
-    redirectTo: '/board',
-  },
-];
 
 @NgModule({
   declarations: [
@@ -46,6 +36,7 @@ const appRoutes: Routes = [
   imports: [
     BrowserAnimationsModule,
     BrowserModule,
+    HttpClientModule,
     MatCardModule,
     MatDividerModule,
     MatIconModule,
@@ -54,9 +45,11 @@ const appRoutes: Routes = [
     MatButtonModule,
     MatInputModule,
     AppRoutingModule,
-    RouterModule.forRoot(
-      appRoutes,
-      { enableTracing: true } // <-- debugging purposes only
+    // The HttpClientInMemoryWebApiModule module intercepts HTTP requests
+    // and returns simulated server responses.
+    // Remove it when a real server is ready to receive requests.
+    HttpClientInMemoryWebApiModule.forRoot(
+      InMemoryDataService, { dataEncapsulation: false }
     )
   ],
   providers: [],

--- a/src/app/board/board.component.html
+++ b/src/app/board/board.component.html
@@ -1,4 +1,7 @@
 <div class="board">
+    <button color="accent" mat-icon-button (click)="newCategory()">
+        <mat-icon>add</mat-icon>
+    </button>
     <mat-card class="category" *ngFor="let category of categories">
         <app-category-detail [category]="category"></app-category-detail>
     </mat-card>

--- a/src/app/board/board.component.ts
+++ b/src/app/board/board.component.ts
@@ -24,12 +24,12 @@ export class BoardComponent implements OnInit {
     this.categoryService.getCategories()
       .subscribe(categories => this.categories = categories);
   }
-  
+
   newCategory(): void {
-    this.categories.push(new Category());
+    this.addCategory('');
   }
 
-  onSubmit(title: string) {
+  addCategory(title: string) {
     this.categoryService.add({ title } as Category).subscribe(category => {
       this.categories.push(category);
     });

--- a/src/app/board/board.component.ts
+++ b/src/app/board/board.component.ts
@@ -24,4 +24,14 @@ export class BoardComponent implements OnInit {
     this.categoryService.getCategories()
       .subscribe(categories => this.categories = categories);
   }
+  
+  newCategory(): void {
+    this.categories.push(new Category());
+  }
+
+  onSubmit(title: string) {
+    this.categoryService.add({ title } as Category).subscribe(category => {
+      this.categories.push(category);
+    });
+  }
 }

--- a/src/app/board/board.component.ts
+++ b/src/app/board/board.component.ts
@@ -9,7 +9,7 @@ import { CategoryService } from '../service/category.service';
   providers: [CategoryService]
 })
 export class BoardComponent implements OnInit {
-  categories: Category[];
+  categories: Category[] = [];
   title: string;
 
   constructor(private categoryService: CategoryService) {
@@ -17,6 +17,11 @@ export class BoardComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.categories = this.categoryService.getStatuses();
+    this.getCategories();
+  }
+
+  getCategories(): void {
+    this.categoryService.getCategories()
+      .subscribe(categories => this.categories = categories);
   }
 }

--- a/src/app/category-detail/category-detail.component.html
+++ b/src/app/category-detail/category-detail.component.html
@@ -1,5 +1,10 @@
 <mat-card tabindex="1" class="category">
-    <mat-card-title>{{ this.getTitle() }}</mat-card-title>
+    <mat-card-title>
+            <input #categoryName matInput placeholder="Enter Category Name..." value="{{this.getTitle()}}" readonly="{{this.readonly}}">
+            <button mat-icon-button (click)="toggleEdit()">
+                <mat-icon>edit</mat-icon>
+            </button>
+    </mat-card-title>
     <div class="task-container">
         <div class="task" *ngFor="let task of tasks">
             <app-task-detail [task]="task"></app-task-detail>

--- a/src/app/category-detail/category-detail.component.ts
+++ b/src/app/category-detail/category-detail.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit, Input } from '@angular/core';
 import { Task } from '../model/task';
 import { Category } from '../model/category';
+import { CategoryService } from '../service/category.service';
 
 @Component({
   selector: 'app-category-detail',
@@ -9,13 +10,20 @@ import { Category } from '../model/category';
 })
 export class CategoryDetailComponent implements OnInit {
   tasks: Task[];
-
+  readonly: string = "true";
   @Input() category: Category;
-  constructor() {
+  constructor(private categoryService: CategoryService) {
+
   }
 
   ngOnInit() {
-    this.tasks = this.category.tasks;
+    this.getTasks();
+  }
+
+  getTasks(): void {
+    this.categoryService.getCategoryById(this.category.id).subscribe(category => {
+      this.tasks = category.tasks;
+    });
   }
 
   getTitle(): string {
@@ -23,6 +31,10 @@ export class CategoryDetailComponent implements OnInit {
   }
 
   add() {
-    this.category.tasks.push(new Task(42, 'test', 'test', 'test'));
+    this.tasks.push(new Task(42, 'test', 'test', 'test'));
+  }
+
+  toggleEdit() {
+    this.readonly = this.readonly == "true" ? "false" : "true";
   }
 }

--- a/src/app/category-detail/category-detail.component.ts
+++ b/src/app/category-detail/category-detail.component.ts
@@ -37,7 +37,10 @@ export class CategoryDetailComponent implements OnInit {
 
   // TODO: this should be adding / subscribing to the InMemoryDataService
   add() {
-    this.tasks.push(new Task(42, 'test', 'test', 'test'));
+    this.categoryService.addTask(this.category.id, { title: 'test', description: 'test', assignedTo: 'test' } as Task)
+      .subscribe(task => {
+        this.tasks.push(task);
+      });
   }
 
   toggleEdit() {

--- a/src/app/category-detail/category-detail.component.ts
+++ b/src/app/category-detail/category-detail.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, Input } from '@angular/core';
-import { Task } from '../model/task'
+import { Task } from '../model/task';
 import { Category } from '../model/category';
 
 @Component({
@@ -11,13 +11,13 @@ export class CategoryDetailComponent implements OnInit {
   tasks: Task[];
 
   @Input() category: Category;
-  constructor() { 
+  constructor() {
   }
-  
+
   ngOnInit() {
     this.tasks = this.category.tasks;
   }
-  
+
   getTitle(): string {
     return this.category.title;
   }

--- a/src/app/category-detail/category-detail.component.ts
+++ b/src/app/category-detail/category-detail.component.ts
@@ -10,10 +10,12 @@ import { CategoryService } from '../service/category.service';
 })
 export class CategoryDetailComponent implements OnInit {
   tasks: Task[];
-  readonly: string = "true";
+  readonly: string;
+
   @Input() category: Category;
   constructor(private categoryService: CategoryService) {
-
+    this.tasks = [];
+    this.readonly = 'true';
   }
 
   ngOnInit() {
@@ -22,7 +24,7 @@ export class CategoryDetailComponent implements OnInit {
 
   getTasks(): void {
     this.categoryService.getCategoryById(this.category.id).subscribe(category => {
-      this.tasks = category.tasks;
+      this.tasks = category.tasks !== undefined ? category.tasks : [];
     });
   }
 
@@ -30,11 +32,12 @@ export class CategoryDetailComponent implements OnInit {
     return this.category.title;
   }
 
+  // TODO: this should be adding / subscribing to the InMemoryDataService
   add() {
     this.tasks.push(new Task(42, 'test', 'test', 'test'));
   }
 
   toggleEdit() {
-    this.readonly = this.readonly == "true" ? "false" : "true";
+    this.readonly = this.readonly === 'true' ? 'false' : 'true';
   }
 }

--- a/src/app/category-detail/category-detail.component.ts
+++ b/src/app/category-detail/category-detail.component.ts
@@ -20,6 +20,9 @@ export class CategoryDetailComponent implements OnInit {
 
   ngOnInit() {
     this.getTasks();
+    if (this.getTitle() === '') {
+      this.toggleEdit();
+    }
   }
 
   getTasks(): void {

--- a/src/app/footer/footer.component.css
+++ b/src/app/footer/footer.component.css
@@ -16,8 +16,3 @@
 .about-us {
     font-size: 20px;
 }
-
-.company-title {
-    font-size: 20px;
-}
-

--- a/src/app/footer/footer.component.html
+++ b/src/app/footer/footer.component.html
@@ -1,5 +1,4 @@
 <mat-toolbar color="primary" class="footer">
     <span class="about-us">About us</span>
     <span class="filler"></span>
-    <span class="company-title">frenchtoast.io</span>
 </mat-toolbar>

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -9,3 +9,4 @@
         <button mat-raised-button (click)="onSubmit(categoryName.value);categoryName.value=''">Submit</button>
     </form>
 </mat-toolbar>
+<router-outlet></router-outlet>

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -1,11 +1,14 @@
 <mat-toolbar color="primary" class="header-nav">
-    <!-- The "return false" below is a JQuery-free hack to make it 
-        so that form submit does not refresh the page. 
-        ref: https://stackoverflow.com/a/22772518 -->
-    <form class="form" onsubmit="return false" class="add-category">
-        <mat-form-field>
-            <input #categoryName matInput placeholder="Add Category">
-        </mat-form-field>
-        <button mat-raised-button (click)="onSubmit(categoryName.value);categoryName.value=''">Submit</button>
-    </form>
+    <mat-toolbar-row>
+        <span>frenchtoast.io</span>
+        <!-- The "return false" below is a JQuery-free hack to make it 
+            so that form submit does not refresh the page. 
+            ref: https://stackoverflow.com/a/22772518 -->
+        <form class="form" onsubmit="return false" class="add-category">
+            <mat-form-field color="accent">
+                <input #categoryName matInput placeholder="Add Category">
+            </mat-form-field>
+            <button mat-raised-button (click)="onSubmit(categoryName.value);categoryName.value=''">Submit</button>
+        </form>
+    </mat-toolbar-row>
 </mat-toolbar>

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -9,4 +9,3 @@
         <button mat-raised-button (click)="onSubmit(categoryName.value);categoryName.value=''">Submit</button>
     </form>
 </mat-toolbar>
-<router-outlet></router-outlet>

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -1,6 +1,4 @@
 import { Component, OnInit } from '@angular/core';
-import { Category } from '../model/category';
-import { CategoryService } from '../service/category.service';
 
 @Component({
   selector: 'app-header',
@@ -8,12 +6,8 @@ import { CategoryService } from '../service/category.service';
   styleUrls: ['./header.component.css'],
 })
 export class HeaderComponent implements OnInit {
-  constructor(private categoryService: CategoryService) { }
+  constructor() { }
 
   ngOnInit() {
-  }
-
-  onSubmit(title: string) {
-    this.categoryService.add({ title } as Category);
   }
 }

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -5,16 +5,15 @@ import { CategoryService } from '../service/category.service';
 @Component({
   selector: 'app-header',
   templateUrl: './header.component.html',
-  styleUrls: ['./header.component.css']
+  styleUrls: ['./header.component.css'],
 })
 export class HeaderComponent implements OnInit {
-
   constructor(private categoryService: CategoryService) { }
 
   ngOnInit() {
   }
 
   onSubmit(title: string) {
-    this.categoryService.add(new Category(title));
+    this.categoryService.add({ title } as Category);
   }
 }

--- a/src/app/in-memory-data.service.spec.ts
+++ b/src/app/in-memory-data.service.spec.ts
@@ -1,0 +1,12 @@
+import { TestBed } from '@angular/core/testing';
+
+import { InMemoryDataService } from './in-memory-data.service';
+
+describe('InMemoryDataService', () => {
+  beforeEach(() => TestBed.configureTestingModule({}));
+
+  it('should be created', () => {
+    const service: InMemoryDataService = TestBed.get(InMemoryDataService);
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/in-memory-data.service.ts
+++ b/src/app/in-memory-data.service.ts
@@ -1,0 +1,73 @@
+import { InMemoryDbService } from 'angular-in-memory-web-api';
+import { ICategory } from './model/category';
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class InMemoryDataService implements InMemoryDbService {
+  createDb() {
+    const categories = [
+      {
+        id: 0,
+        title: 'Backlog',
+        tasks: [
+          {
+            id: 1,
+            title: 'Lame task',
+            description: 'It\'s lame',
+            assignedTo: 'Jesse'
+          },
+          {
+            id: 2,
+            title: 'Fun task',
+            description: 'It\'s fun',
+            assignedTo: 'Eric'
+          },
+          {
+            id: 3,
+            title: 'Cool task',
+            description: 'It\'s cool',
+            assignedTo: 'Canyon'
+          }
+        ]
+      },
+      {
+        id: 1,
+        title: 'In Progress',
+        tasks: [
+          {
+            id: 4,
+            title: 'Active task',
+            description: 'I\'m doin\' it',
+            assignedTo: 'Jesse'
+          }
+        ]
+      },
+      {
+        id: 2,
+        title: 'Done',
+        tasks: [
+          {
+            id: 5,
+            title: 'Completed task',
+            description: 'It be done mon',
+            assignedTo: 'Eric'
+          }
+        ]
+      },
+
+    ];
+
+    return { categories };
+  }
+
+  // Overrides the genId method to ensure that a hero always has an id.
+  // If the heroes array is empty,
+  // the method below returns the initial number (11).
+  // if the heroes array is not empty, the method below returns the highest
+  // hero id + 1.
+  genId(categories: ICategory[]): number {
+    return categories.length > 0 ? Math.max(...categories.map(category => category.id)) + 1 : 0;
+  }
+}

--- a/src/app/mock/categories.ts
+++ b/src/app/mock/categories.ts
@@ -1,50 +1,53 @@
 import { ICategory } from '../model/category';
 
-export const STATUSES: ICategory[] = [
+export const CATEGORIES: ICategory[] = [
     {
-        title: "Backlog",
+        id: 0,
+        title: 'Backlog',
         tasks: [
             {
                 id: 1,
-                title: "Lame task",
-                description: "It's lame",
-                assignedTo: "Jesse"
+                title: 'Lame task',
+                description: 'It\'s lame',
+                assignedTo: 'Jesse'
             },
             {
                 id: 2,
-                title: "Fun task",
-                description: "It's fun",
-                assignedTo: "Eric"
+                title: 'Fun task',
+                description: 'It\'s fun',
+                assignedTo: 'Eric'
             },
             {
                 id: 3,
-                title: "Cool task",
-                description: "It's cool",
-                assignedTo: "Canyon"
+                title: 'Cool task',
+                description: 'It\'s cool',
+                assignedTo: 'Canyon'
             }
         ]
     },
     {
-        title: "In Progress",
+        id: 1,
+        title: 'In Progress',
         tasks: [
             {
                 id: 4,
-                title: "Active task",
-                description: "I'm doin' it",
-                assignedTo: "Jesse"
+                title: 'Active task',
+                description: 'I\'m doin\' it',
+                assignedTo: 'Jesse'
             }
         ]
     },
     {
-        title: "Done",
+        id: 2,
+        title: 'Done',
         tasks: [
             {
                 id: 5,
-                title: "Completed task",
-                description: "It be done mon",
-                assignedTo: "Eric"
+                title: 'Completed task',
+                description: 'It be done mon',
+                assignedTo: 'Eric'
             }
         ]
     },
-    
-]
+
+];

--- a/src/app/model/category.ts
+++ b/src/app/model/category.ts
@@ -1,16 +1,18 @@
 import { Task } from './task';
 
 export interface ICategory {
+    id: number;
     title: string;
     tasks: Task[];
 }
 
 export class Category implements ICategory {
 
+    id: number;
     title: string;
     tasks: Task[];
 
-    constructor(title: string) {
+    constructor(id: number, title: string) {
         this.title = title;
         this.tasks = [];
     }

--- a/src/app/model/category.ts
+++ b/src/app/model/category.ts
@@ -9,12 +9,10 @@ export interface ICategory {
 export class Category implements ICategory {
 
     id: number;
-    title: string;
-    tasks: Task[];
+    title = '';
+    tasks: Task[] = [];
 
     constructor(title?: string) {
-        this.title = "";
-        this.tasks = [];
         if (title) {
             this.title = title;
         }

--- a/src/app/model/category.ts
+++ b/src/app/model/category.ts
@@ -12,8 +12,11 @@ export class Category implements ICategory {
     title: string;
     tasks: Task[];
 
-    constructor(id: number, title: string) {
-        this.title = title;
+    constructor(title?: string) {
+        this.title = "";
         this.tasks = [];
+        if (title) {
+            this.title = title;
+        }
     }
 }

--- a/src/app/service/category.service.ts
+++ b/src/app/service/category.service.ts
@@ -1,23 +1,48 @@
 import { Injectable } from '@angular/core';
 import { Category } from '../model/category';
-import { STATUSES } from '../mock/categories';
+import { catchError, map, tap } from 'rxjs/operators';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { Observable, of } from 'rxjs';
 
 @Injectable({
   providedIn: 'root'
 })
 export class CategoryService {
+  private categoriesUrl = 'api/categories';
 
-  categories: Category[];
+  httpOptions = {
+    headers: new HttpHeaders({ 'Content-Type': 'application/json' })
+  };
 
-  constructor() {
-    this.categories = STATUSES;
+  constructor(private http: HttpClient) {
   }
 
-  add(category: Category) {
-    this.categories.push(category);
+  add(category: Category): Observable<Category> {
+    if (!category) { return; }
+    return this.http.post<Category>(this.categoriesUrl, category, this.httpOptions).pipe(catchError(this.handleError<Category>('add')));
   }
 
-  getStatuses(): Category[] {
-    return this.categories;
+  getCategories(): Observable<Category[]> {
+    return this.http.get<Category[]>(this.categoriesUrl).pipe(catchError(this.handleError<Category[]>('getCategories', [])));
+  }
+
+  /**
+   * Handle Http operation that failed.
+   * Let the app continue.
+   * @param operation - name of the operation that failed
+   * @param result - optional value to return as the observable result
+   */
+  private handleError<T>(operation = 'operation', result?: T) {
+    return (error: any): Observable<T> => {
+
+      // TODO: send the error to remote logging infrastructure
+      console.error(error); // log to console instead
+
+      // TODO: better job of transforming error for user consumption
+      console.log(`${operation} failed: ${error.message}`);
+
+      // Let the app keep running by returning an empty result.
+      return of(result as T);
+    };
   }
 }

--- a/src/app/service/category.service.ts
+++ b/src/app/service/category.service.ts
@@ -26,6 +26,11 @@ export class CategoryService {
     return this.http.get<Category[]>(this.categoriesUrl).pipe(catchError(this.handleError<Category[]>('getCategories', [])));
   }
 
+  getCategoryById(id: number): Observable<Category> {
+    const url = `${this.categoriesUrl}/${id}`;
+    return this.http.get<Category>(url);
+  }
+
   /**
    * Handle Http operation that failed.
    * Let the app continue.

--- a/src/app/service/category.service.ts
+++ b/src/app/service/category.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Category } from '../model/category';
+import { Task } from '../model/task'
 import { catchError, map, tap } from 'rxjs/operators';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Observable, of } from 'rxjs';
@@ -20,6 +21,12 @@ export class CategoryService {
   add(category: Category): Observable<Category> {
     if (!category) { return; }
     return this.http.post<Category>(this.categoriesUrl, category, this.httpOptions).pipe(catchError(this.handleError<Category>('add')));
+  }
+
+  addTask(categoryId: number, task: Task): Observable<Task> {
+    const url = `${this.categoriesUrl}/${categoryId}/tasks`;
+    if (!task) { return; }
+    return this.http.post<Task>(url, task, this.httpOptions).pipe(catchError(this.handleError<Task>('addTask')));
   }
 
   getCategories(): Observable<Category[]> {

--- a/src/app/task-detail/task-detail.component.ts
+++ b/src/app/task-detail/task-detail.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, Input } from '@angular/core';
-import { Task } from "../model/task"
+import { Task } from '../model/task';
 
 @Component({
   selector: 'app-task-detail',


### PR DESCRIPTION
Implement the [Angular "In Memory Web API"](https://angular.io/tutorial/toh-pt6) database service as a mock database. This allows us to program as if we already have a database (such as mongoDB) hosted and ready to go. Once we get our server up and running, we simply change the endpoint urls.

Right now adding Tasks does some weird things:

![deng2](https://user-images.githubusercontent.com/9259993/65810985-b3257100-e166-11e9-961c-d3aa857e03a6.gif)

I think it has something to do with the way we're subscribing to `CategoryService` from 3 or more different instances of `CategoryDetailComponent`. 
